### PR TITLE
Update techempower benchmark run in any OCP/K8's namespace

### DIFF
--- a/techempower/docker/README.MD
+++ b/techempower/docker/README.MD
@@ -1,0 +1,39 @@
+TFB postgres database
+=====================
+
+Build image:
+
+```shell
+$ docker build -f ./postgres.dockerfile --tag johara/tfb-postgres  .
+Sending build context to Docker daemon  7.168kB
+Step 1/2 : FROM quay.io/centos7/postgresql-13-centos7:latest
+ ---> 32cc569aeaf5
+Step 2/2 : ADD create-postgres-data.sql /tmp/create-postgres-data.sql
+ ---> 0c1cc9fcf423
+Successfully built 0c1cc9fcf423
+Successfully tagged johara/tfb-postgres:latest
+```
+
+Tag Image:
+
+```shell
+$ docker tag 0c1cc9fcf423 quay.io/johara/tfb-database:latest
+```
+
+Login:
+
+```shell
+$ docker login quay.io
+```
+
+Push Image:
+
+```shell
+$ docker push quay.io/johara/tfb-database
+Using default tag: latest
+The push refers to repository [quay.io/johara/tfb-database]
+987b88cd2691: Pushed 
+...
+53498d66ad83: Layer already exists 
+latest: digest: sha256:1f6e8facebf6b4f3de40e1dfd1b7e5649d80845c7810146f8b36c23097367c7c size: 2411
+```

--- a/techempower/docker/create-postgres-data.sql
+++ b/techempower/docker/create-postgres-data.sql
@@ -1,0 +1,65 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+CREATE TABLE  World (
+  id integer NOT NULL,
+  randomNumber integer NOT NULL default 0,
+  PRIMARY KEY  (id)
+);
+GRANT ALL PRIVILEGES ON World to benchmarkdbuser;
+
+INSERT INTO World (id, randomnumber)
+SELECT x.id, least(floor(random() * 10000 + 1), 10000) FROM generate_series(1,10000) as x(id);
+
+CREATE TABLE Fortune (
+  id integer NOT NULL,
+  message varchar(2048) NOT NULL,
+  PRIMARY KEY  (id)
+);
+GRANT ALL PRIVILEGES ON Fortune to benchmarkdbuser;
+
+INSERT INTO Fortune (id, message) VALUES (1, 'fortune: No such file or directory');
+INSERT INTO Fortune (id, message) VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');
+INSERT INTO Fortune (id, message) VALUES (3, 'After enough decimal places, nobody gives a damn.');
+INSERT INTO Fortune (id, message) VALUES (4, 'A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1');
+INSERT INTO Fortune (id, message) VALUES (5, 'A computer program does what you tell it to do, not what you want it to do.');
+INSERT INTO Fortune (id, message) VALUES (6, 'Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen');
+INSERT INTO Fortune (id, message) VALUES (7, 'Any program that runs right is obsolete.');
+INSERT INTO Fortune (id, message) VALUES (8, 'A list is only as strong as its weakest link. — Donald Knuth');
+INSERT INTO Fortune (id, message) VALUES (9, 'Feature: A bug with seniority.');
+INSERT INTO Fortune (id, message) VALUES (10, 'Computers make very fast, very accurate mistakes.');
+INSERT INTO Fortune (id, message) VALUES (11, '<script>alert("This should not be displayed in a browser alert box.");</script>');
+INSERT INTO Fortune (id, message) VALUES (12, 'フレームワークのベンチマーク');
+
+CREATE TABLE  "World" (
+  id integer NOT NULL,
+  randomNumber integer NOT NULL default 0,
+  PRIMARY KEY  (id)
+);
+GRANT ALL PRIVILEGES ON "World" to benchmarkdbuser;
+
+INSERT INTO "World" (id, randomnumber)
+SELECT x.id, least(floor(random() * 10000 + 1), 10000) FROM generate_series(1,10000) as x(id);
+
+CREATE TABLE "Fortune" (
+  id integer NOT NULL,
+  message varchar(2048) NOT NULL,
+  PRIMARY KEY  (id)
+);
+GRANT ALL PRIVILEGES ON "Fortune" to benchmarkdbuser;
+
+INSERT INTO "Fortune" (id, message) VALUES (1, 'fortune: No such file or directory');
+INSERT INTO "Fortune" (id, message) VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');
+INSERT INTO "Fortune" (id, message) VALUES (3, 'After enough decimal places, nobody gives a damn.');
+INSERT INTO "Fortune" (id, message) VALUES (4, 'A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1');
+INSERT INTO "Fortune" (id, message) VALUES (5, 'A computer program does what you tell it to do, not what you want it to do.');
+INSERT INTO "Fortune" (id, message) VALUES (6, 'Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen');
+INSERT INTO "Fortune" (id, message) VALUES (7, 'Any program that runs right is obsolete.');
+INSERT INTO "Fortune" (id, message) VALUES (8, 'A list is only as strong as its weakest link. — Donald Knuth');
+INSERT INTO "Fortune" (id, message) VALUES (9, 'Feature: A bug with seniority.');
+INSERT INTO "Fortune" (id, message) VALUES (10, 'Computers make very fast, very accurate mistakes.');
+INSERT INTO "Fortune" (id, message) VALUES (11, '<script>alert("This should not be displayed in a browser alert box.");</script>');
+INSERT INTO "Fortune" (id, message) VALUES (12, 'フレームワークのベンチマーク');
+
+COMMIT;

--- a/techempower/docker/postgres.dockerfile
+++ b/techempower/docker/postgres.dockerfile
@@ -1,0 +1,4 @@
+#FROM registry.redhat.io/rhel8/postgresql-13:latest
+FROM quay.io/centos7/postgresql-13-centos7:latest
+
+ADD create-postgres-data.sql /tmp/create-postgres-data.sql

--- a/techempower/manifests/postgres.yaml
+++ b/techempower/manifests/postgres.yaml
@@ -32,7 +32,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "sleep 10 && psql -a hello_world < /tmp/create-postgres.sql"]        
+              command: ["/bin/sh", "-c", "sleep 10 && psql -a hello_world < /tmp/create-postgres-data.sql"]        
         ports:
           - containerPort: 5432
         resources:

--- a/techempower/manifests/postgres.yaml
+++ b/techempower/manifests/postgres.yaml
@@ -20,15 +20,19 @@ spec:
     spec:
       containers:
       - name: tfb-database
-        image: kruize/tfb-postgres:latest
-        imagePullPolicy: IfNotPresent
+        image: quay.io/johara/tfb-database:latest
+        imagePullPolicy: Always
         env:
-          - name: POSTGRES_USER
+          - name: POSTGRESQL_USER
             value: benchmarkdbuser
-          - name: POSTGRES_PASSWORD
+          - name: POSTGRESQL_PASSWORD
             value: benchmarkdbpass
-          - name: POSTGRES_DB
+          - name: POSTGRESQL_PASSWORD
             value: hello_world
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 10 && psql -a hello_world < /tmp/create-postgres.sql"]        
         ports:
           - containerPort: 5432
         resources:

--- a/techempower/manifests/postgres.yaml
+++ b/techempower/manifests/postgres.yaml
@@ -27,7 +27,7 @@ spec:
             value: benchmarkdbuser
           - name: POSTGRESQL_PASSWORD
             value: benchmarkdbpass
-          - name: POSTGRESQL_PASSWORD
+          - name: POSTGRESQL_DATABASE
             value: hello_world
         lifecycle:
           postStart:

--- a/techempower/manifests/postgres.yaml
+++ b/techempower/manifests/postgres.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: tfb-database
         image: quay.io/johara/tfb-database:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: POSTGRESQL_USER
             value: benchmarkdbuser

--- a/techempower/manifests/quarkus-resteasy-hibernate-0.yaml
+++ b/techempower/manifests/quarkus-resteasy-hibernate-0.yaml
@@ -21,9 +21,6 @@ spec:
     spec:
       volumes:
       - name: test-volume
-        hostPath:
-          path: "/root/icp/jLogs"
-          type: ""
       containers:
       - name: tfb-server
         image: kruize/tfb-qrh:1.13.2.F_mm.v1

--- a/techempower/manifests/quarkus-resteasy-hibernate.yaml
+++ b/techempower/manifests/quarkus-resteasy-hibernate.yaml
@@ -21,9 +21,6 @@ spec:
     spec:
       volumes:
       - name: test-volume
-        hostPath:
-          path: "/root/icp/jLogs"
-          type: ""
       containers:
       - name: tfb-server
         image: kruize/tfb-qrh:1.13.2.F_mm.v1

--- a/techempower/scripts/perf/run-tfb-qrh-openshift.sh
+++ b/techempower/scripts/perf/run-tfb-qrh-openshift.sh
@@ -332,7 +332,7 @@ function runIterations() {
 		echo "***************************************" >> ${LOGFILE}
 		if [ ${RE_DEPLOY} == "true" ]; then
 			echo "Deploying the application..." >> ${LOGFILE}
-			${SCRIPT_REPO}/tfb-qrh-deploy-openshift.sh -s ${BENCHMARK_SERVER} -i ${SCALING} -g ${TFB_IMAGE} --cpureq=${CPU_REQ} --memreq=${MEM_REQ} --cpulim=${CPU_LIM} --memlim=${MEM_LIM} --maxinlinelevel=${maxinlinelevel} --quarkustpcorethreads=${quarkustpcorethreads} --quarkustpqueuesize=${quarkustpqueuesize} --quarkusdatasourcejdbcminsize=${quarkusdatasourcejdbcminsize} --quarkusdatasourcejdbcmaxsize=${quarkusdatasourcejdbcmaxsize} >> ${LOGFILE}
+			${SCRIPT_REPO}/tfb-qrh-deploy-openshift.sh -s ${BENCHMARK_SERVER} -n ${NAMESPACE} -i ${SCALING} -g ${TFB_IMAGE} --cpureq=${CPU_REQ} --memreq=${MEM_REQ} --cpulim=${CPU_LIM} --memlim=${MEM_LIM} --maxinlinelevel=${maxinlinelevel} --quarkustpcorethreads=${quarkustpcorethreads} --quarkustpqueuesize=${quarkustpqueuesize} --quarkusdatasourcejdbcminsize=${quarkusdatasourcejdbcminsize} --quarkusdatasourcejdbcmaxsize=${quarkusdatasourcejdbcmaxsize} >> ${LOGFILE}
 			# err_exit "Error: tfb-qrh deployment failed" >> ${LOGFILE}
 		fi
 		# Start the load

--- a/techempower/scripts/tfb-qrh-deploy-openshift.sh
+++ b/techempower/scripts/tfb-qrh-deploy-openshift.sh
@@ -147,7 +147,7 @@ function createInstances() {
 
 	# Deploy one instance of DB
 	oc create -f ${MANIFESTS_DIR}/postgres.yaml -n ${NAMESPACE}
-	sleep 10
+	sleep 15
 
 	for(( inst=0; inst<"${SERVER_INSTANCES}"; inst++ ))
 	do

--- a/techempower/scripts/tfb-qrh-deploy-openshift.sh
+++ b/techempower/scripts/tfb-qrh-deploy-openshift.sh
@@ -213,7 +213,7 @@ function createInstances() {
 
 # Delete the tfb-qrh and tfb-database deployments,services and routes if it is already present 
 function stopAllInstances() {
-	${TFB_REPO}/tfb-cleanup.sh -c ${CLUSTER_TYPE} >> ${LOGFILE}
+	${TFB_REPO}/tfb-cleanup.sh -c ${CLUSTER_TYPE} -n ${NAMESPACE}>> ${LOGFILE}
 	sleep 30
 
 	##extra sleep time


### PR DESCRIPTION
These changes allow the benchmark pods to run as non-privileged pods.  This allows the benchmark to run in any namespace in OpenShift/ K8's without having to deploy to the `default` namespace.

You may wish to change the `image:` in `techempower/manifests/postgres.yaml` to an image that you manage. At the moment the image has been build from `techempower/docker/postgres.dockerfile` and is being served from a repo on quay.io